### PR TITLE
feat: add boost caps and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,24 @@ subscribed_instances:
 # Filter posts from specific instances
 filtered_instances:
   - example.com
+
+daily_public_cap: 24
+per_hour_public_cap: 1
+rotate_instances: true
+require_media: true
+skip_sensitive_without_cw: true
+languages_allowlist:
+  - en
+  - sv
+state_path: "/app/secrets/state.json"
 ```
 
 ## Features
 
 - Boost trending posts from other Mastodon instances
 - Update bot profile with list of subscribed instances
+- Rotate through subscribed instances
+- Enforce hourly and daily caps on public boosts
+- Skip reposts and filter posts without media or missing content warnings
 
 ---

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,3 +26,13 @@ subscribed_instances:
 # other instances
 filtered_instances:
   - example.com
+
+daily_public_cap: 24
+per_hour_public_cap: 1
+rotate_instances: true
+require_media: true
+skip_sensitive_without_cw: true
+languages_allowlist:
+  - en
+  - sv
+state_path: "/app/secrets/state.json"

--- a/hype/config.py
+++ b/hype/config.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List
+from datetime import timezone
 
 import yaml
 
@@ -30,12 +31,19 @@ class Instance:
 
 class Config:
     bot_account: BotAccount
-    interval: int = 60  # minutes
+    interval: int = 60
     log_level: str = "INFO"
     subscribed_instances: List = []
     filtered_instances: List = []
     profile_prefix: str = ""
     fields: dict = {}
+    daily_public_cap: int = 24
+    per_hour_public_cap: int = 1
+    rotate_instances: bool = True
+    require_media: bool = True
+    skip_sensitive_without_cw: bool = True
+    languages_allowlist: list = []
+    state_path: str = "/app/secrets/state.json"
 
     def __init__(self):
         # auth file containing login info
@@ -100,6 +108,28 @@ class Config:
                     if config.get("filtered_instances")
                     else []
                 )
+
+                self.daily_public_cap = int(
+                    config.get("daily_public_cap", self.daily_public_cap)
+                )
+                self.per_hour_public_cap = int(
+                    config.get("per_hour_public_cap", self.per_hour_public_cap)
+                )
+                self.rotate_instances = bool(
+                    config.get("rotate_instances", self.rotate_instances)
+                )
+                self.require_media = bool(
+                    config.get("require_media", self.require_media)
+                )
+                self.skip_sensitive_without_cw = bool(
+                    config.get(
+                        "skip_sensitive_without_cw", self.skip_sensitive_without_cw
+                    )
+                )
+                self.languages_allowlist = config.get(
+                    "languages_allowlist", self.languages_allowlist
+                ) or []
+                self.state_path = config.get("state_path", self.state_path)
 
 
 class ConfigException(Exception):

--- a/hype/hype.py
+++ b/hype/hype.py
@@ -1,6 +1,8 @@
+import json
 import logging
 import os.path
 import time
+from datetime import datetime, timezone
 
 import schedule
 from mastodon import Mastodon
@@ -17,14 +19,16 @@ class Hype:
             datefmt="%Y-%m-%d %H:%M:%S",
         )
         self.log = logging.getLogger("hype")
+        self.instance_index = 0
+        self.state = self._load_state()
         self.log.info("Config loaded")
 
     def login(self):
         self.log.info(f"Logging in to {self.config.bot_account.server}")
         self.client = Mastodon(
             api_base_url=self.config.bot_account.server,
-            access_token=self.config.bot_account.access_token
-          )
+            access_token=self.config.bot_account.access_token,
+        )
 
     def update_profile(self):
         self.log.info("Update bot profile")
@@ -32,51 +36,144 @@ class Hype:
             [f"- {instance}" for instance in self.config.subscribed_instances]
         )
         note = f"""{self.config.profile_prefix}
-        {subscribed_instances_list}
-        """
+{subscribed_instances_list}
+"""
         fields = [(key, value) for key, value in self.config.fields.items()]
         self.client.account_update_credentials(
             note=note, bot=True, discoverable=True, fields=fields
         )
+        self.state["last_instance_index"] = self.instance_index
+        self._save_state()
+
+    def _load_state(self):
+        try:
+            if os.path.isfile(self.config.state_path):
+                with open(self.config.state_path, "r") as handle:
+                    data = json.load(handle)
+                    data.setdefault("seen_status_ids", [])
+                    return data
+        except Exception:
+            pass
+        return {
+            "seen_status_ids": [],
+            "last_instance_index": 0,
+            "day": "",
+            "day_count": 0,
+            "hour": "",
+            "hour_count": 0,
+        }
+
+    def _save_state(self):
+        try:
+            with open(self.config.state_path, "w") as handle:
+                json.dump(self.state, handle)
+        except Exception as err:
+            self.log.error(f"could not persist state: {err}")
+
+    def _tick_counters(self):
+        now = datetime.now(timezone.utc)
+        day_key = now.strftime("%Y-%m-%d")
+        hour_key = now.strftime("%Y-%m-%dT%H")
+        if self.state.get("day") != day_key:
+            self.state["day"] = day_key
+            self.state["day_count"] = 0
+        if self.state.get("hour") != hour_key:
+            self.state["hour"] = hour_key
+            self.state["hour_count"] = 0
+
+    def _public_cap_available(self) -> bool:
+        self._tick_counters()
+        return (
+            self.state["day_count"] < self.config.daily_public_cap
+            and self.state["hour_count"] < self.config.per_hour_public_cap
+        )
+
+    def _count_public_boost(self):
+        self._tick_counters()
+        self.state["day_count"] += 1
+        self.state["hour_count"] += 1
+
+    def _should_skip_status(self, status: dict) -> bool:
+        if self.config.require_media and not status.get("media_attachments"):
+            return True
+        if (
+            self.config.skip_sensitive_without_cw
+            and status.get("sensitive")
+            and not (status.get("spoiler_text") or "").strip()
+        ):
+            return True
+        if self.config.languages_allowlist:
+            lang = (status.get("language") or "").lower()
+            if lang not in self.config.languages_allowlist:
+                return True
+        return False
 
     def boost(self):
         self.log.info("Run boost")
-        for instance in self.config.subscribed_instances:
-            try:
-                # Create mastodon API client
-                mastodon_client = self.init_client(instance.name)
-                # Fetch statuses from every subscribed instance
-                trending_statuses = mastodon_client.trending_statuses()[
-                    : instance.limit
-                ]
-                counter = 0
-                for trending_status in trending_statuses:
-                    counter += 1
-                    # Get snowflake-id of status on the instance where the status will be boosted  # noqa: E501
-                    status = self.client.search_v2(
-                        trending_status["uri"], result_type="statuses"
-                    )["statuses"]
-                    if len(status) > 0:
-                        status = status[0]
-                        # check if post comes from a filtered instance
-                        source_account = status["account"]["acct"].split("@")
-                        server = source_account[-1]
-                        filtered = server in self.config.filtered_instances
-                        # Boost if not already boosted
-                        already_boosted = status["reblogged"]
-                        if not already_boosted and not filtered:
-                            self.client.status_reblog(status)
-                        self.log.info(
-                            f"{instance.name}: {counter}/{len(trending_statuses)} {'ignore' if (already_boosted or filtered)  else 'boost'}"
-                        )
-                    else:
-                        self.log.warning(
-                            f"{instance.name}: {counter}/{len(trending_statuses)} could not find post by id"
-                        )
-            except Exception as e:
-                self.log.error(
-                    f"{instance.name}: Could not fetch instance. Sorry. - {e}"
-                )
+        if not self.config.subscribed_instances:
+            self.log.warning("No subscribed instances configured.")
+            return
+        instances = self.config.subscribed_instances
+        if self.config.rotate_instances:
+            self.instance_index = self.state.get("last_instance_index", 0) % len(
+                instances
+            )
+            target = instances[self.instance_index]
+            self._boost_instance(target)
+            self.instance_index = (self.instance_index + 1) % len(instances)
+            self.state["last_instance_index"] = self.instance_index
+            self._save_state()
+        else:
+            for inst in instances:
+                self._boost_instance(inst)
+
+    def _boost_instance(self, instance):
+        try:
+            if not self._public_cap_available():
+                self.log.info("Public cap reached. Skipping boosting this cycle.")
+                return
+            mastodon_client = self.init_client(instance.name)
+            trending_statuses = mastodon_client.trending_statuses()[: instance.limit]
+            total = len(trending_statuses)
+            processed = 0
+            for trending_status in trending_statuses:
+                result = self.client.search_v2(
+                    trending_status["uri"], result_type="statuses"
+                ).get("statuses", [])
+                if not result:
+                    self.log.info(f"{instance.name}: skip, not found")
+                    continue
+                status = result[0]
+                sid = status["id"]
+                if sid in self.state["seen_status_ids"] or status.get("reblogged"):
+                    self.log.info(f"{instance.name}: already boosted, skip")
+                    continue
+                acct = status["account"]["acct"].split("@")
+                server = acct[-1] if len(acct) > 1 else ""
+                if server in self.config.filtered_instances:
+                    self.log.info(
+                        f"{instance.name}: filtered instance {server}, skip"
+                    )
+                    continue
+                if self._should_skip_status(status):
+                    self.log.info(f"{instance.name}: filtered by rules, skip")
+                    continue
+                if not self._public_cap_available():
+                    self.log.info("Public cap reached before boost. Stopping.")
+                    break
+                self.client.status_reblog(status)
+                self._count_public_boost()
+                self.state["seen_status_ids"].append(sid)
+                if len(self.state["seen_status_ids"]) > 5000:
+                    self.state["seen_status_ids"] = self.state["seen_status_ids"][-3000:]
+                self._save_state()
+                processed += 1
+                self.log.info(f"{instance.name}: boosted {processed}/{total}")
+                if self.state["hour_count"] >= self.config.per_hour_public_cap:
+                    self.log.info("Per-hour public cap reached, stopping early.")
+                    break
+        except Exception as err:
+            self.log.error(f"{instance.name}: error - {err}")
 
     def start(self):
         self.boost()
@@ -101,3 +198,4 @@ class Hype:
             client_id=secret_path,
             ratelimit_method="pace",
         )
+


### PR DESCRIPTION
## Summary
- add config for caps, rotation, and filtering
- persist seen boosts and enforce hourly/daily limits
- document new options and behavior

## Testing
- `python -m py_compile hype/config.py hype/hype.py`
- `pytest`
- `helm version` *(fails: command not found)*
- `apt-get install -y helm` *(fails: package not found)*
- `apt-get install -y kustomize` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e392de4888322bf1a0512da445f5f