### PR TITLE
fix(ci): configure GHCR permissions and versioned tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,11 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   build-and-push-ghcr-image:
     name: Build Docker image and push to GHCR
@@ -14,28 +19,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GHCR
+        run: echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Build and push image (develop branch)
         if: ${{ github.ref_name == 'develop' }}
-        uses: docker/build-push-action@v3
+        id: build_and_push_develop
+        uses: docker/build-push-action@v6
         with:
           context: .
-          tags: ghcr.io/${{ github.repository_owner }}/hypebot:develop
           push: true
+          tags: ghcr.io/${{ github.repository_owner }}/hypebot:develop
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       - name: Build and push image (main branch)
         if: ${{ github.ref_name == 'main' }}
-        uses: docker/build-push-action@v3
+        id: build_and_push_main
+        uses: docker/build-push-action@v6
         with:
           context: .
-          tags: ghcr.io/${{ github.repository_owner }}/hypebot:latest
           push: true
+          tags: ghcr.io/${{ github.repository_owner }}/hypebot:v0.1.0
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       - name: Image digest (develop)
         if: ${{ steps.build_and_push_develop.outcome == 'success' }}

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Deploy with docker-compose
 version: "3"
 services:
   hype:
-    image: valentinriess/hype:latest
+    image: ghcr.io/goingdark-social/hypebot:v0.1.0
     volumes:
       - ./config:/app/config
 ```
+Replace `v0.1.0` with the release you want to run.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- grant workflow token permissions for packages and OIDC
- log into GHCR using `github.token`
- push images with explicit version tags and source label
- update docker-compose instructions to use versioned image

## Testing
- `python -m compileall hype`
- `yamllint .github/workflows/main.yml`


------
https://chatgpt.com/codex/tasks/task_e_689e3df43db08322a1c0f3a8d2895104