### PR TITLE
Track canonical URLs to skip duplicate boosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ state_path: "/app/secrets/state.json"
 - Boost trending posts from other Mastodon instances
 - Update bot profile with list of subscribed instances
 - Rotate through subscribed instances
+- Skip duplicates across instances by tracking canonical URLs
 - Enforce hourly and daily caps on public boosts
 - Skip reposts and filter posts without media or missing content warnings
 
 ---
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml
 Mastodon.py
 schedule
+pytest


### PR DESCRIPTION
## Summary
- track canonical URLs alongside IDs and prune old entries
- document duplicate detection across instances
- cover duplicate handling with tests

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1900166d083228fecd6584ce667a4