### PR TITLE
feat: add traction filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,15 @@ per_hour_public_cap: 1
 rotate_instances: true
 require_media: true
 skip_sensitive_without_cw: true
+min_reblogs: 0
+min_favourites: 0
 languages_allowlist:
   - en
   - sv
 state_path: "/app/secrets/state.json"
 ```
+
+`min_reblogs` and `min_favourites` let you ignore posts that haven't gained enough traction yet.
 
 ## Features
 
@@ -80,5 +84,6 @@ state_path: "/app/secrets/state.json"
 - Rotate through subscribed instances
 - Enforce hourly and daily caps on public boosts
 - Skip reposts and filter posts without media or missing content warnings
+- Skip posts with too few reblogs or favourites
 
 ---

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,6 +32,8 @@ per_hour_public_cap: 1
 rotate_instances: true
 require_media: true
 skip_sensitive_without_cw: true
+min_reblogs: 0
+min_favourites: 0
 languages_allowlist:
   - en
   - sv

--- a/hype/config.py
+++ b/hype/config.py
@@ -42,6 +42,8 @@ class Config:
     rotate_instances: bool = True
     require_media: bool = True
     skip_sensitive_without_cw: bool = True
+    min_reblogs: int = 0
+    min_favourites: int = 0
     languages_allowlist: list = []
     state_path: str = "/app/secrets/state.json"
 
@@ -125,6 +127,12 @@ class Config:
                     config.get(
                         "skip_sensitive_without_cw", self.skip_sensitive_without_cw
                     )
+                )
+                self.min_reblogs = int(
+                    config.get("min_reblogs", self.min_reblogs)
+                )
+                self.min_favourites = int(
+                    config.get("min_favourites", self.min_favourites)
                 )
                 self.languages_allowlist = config.get(
                     "languages_allowlist", self.languages_allowlist

--- a/hype/hype.py
+++ b/hype/hype.py
@@ -106,6 +106,10 @@ class Hype:
             lang = (status.get("language") or "").lower()
             if lang not in self.config.languages_allowlist:
                 return True
+        if status.get("reblogs_count", 0) < self.config.min_reblogs:
+            return True
+        if status.get("favourites_count", 0) < self.config.min_favourites:
+            return True
         return False
 
     def boost(self):


### PR DESCRIPTION
## Summary
- allow setting minimum reblogs and favourites before boosting
- document traction thresholds in sample config and README

## Testing
- `python -m py_compile hype/config.py hype/hype.py`
- `helm version` *(fails: command not found)*
- `./kustomize build .` *(fails: unable to find kustomization file)*

------
https://chatgpt.com/codex/tasks/task_e_68a18fe71b1883228c97bc027475ffa1