### PR TITLE
feat: add max_post_age_minutes filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ per_hour_public_cap: 1
 rotate_instances: true
 require_media: true
 skip_sensitive_without_cw: true
+# Ignore posts older than this many minutes
+max_post_age_minutes: 1440
 languages_allowlist:
   - en
   - sv
@@ -80,5 +82,6 @@ state_path: "/app/secrets/state.json"
 - Rotate through subscribed instances
 - Enforce hourly and daily caps on public boosts
 - Skip reposts and filter posts without media or missing content warnings
+- Ignore posts older than a configurable threshold
 
 ---

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,6 +32,7 @@ per_hour_public_cap: 1
 rotate_instances: true
 require_media: true
 skip_sensitive_without_cw: true
+max_post_age_minutes: 1440
 languages_allowlist:
   - en
   - sv

--- a/hype/config.py
+++ b/hype/config.py
@@ -1,6 +1,5 @@
 import logging
 from typing import List
-from datetime import timezone
 
 import yaml
 
@@ -43,6 +42,7 @@ class Config:
     require_media: bool = True
     skip_sensitive_without_cw: bool = True
     languages_allowlist: list = []
+    max_post_age_minutes: int = 1440
     state_path: str = "/app/secrets/state.json"
 
     def __init__(self):
@@ -129,6 +129,9 @@ class Config:
                 self.languages_allowlist = config.get(
                     "languages_allowlist", self.languages_allowlist
                 ) or []
+                self.max_post_age_minutes = int(
+                    config.get("max_post_age_minutes", self.max_post_age_minutes)
+                )
                 self.state_path = config.get("state_path", self.state_path)
 
 

--- a/hype/hype.py
+++ b/hype/hype.py
@@ -106,6 +106,14 @@ class Hype:
             lang = (status.get("language") or "").lower()
             if lang not in self.config.languages_allowlist:
                 return True
+        created_at_str = status.get("created_at")
+        if created_at_str:
+            created_at = datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
+            age_minutes = (
+                datetime.now(timezone.utc) - created_at
+            ).total_seconds() / 60
+            if age_minutes > self.config.max_post_age_minutes:
+                return True
         return False
 
     def boost(self):


### PR DESCRIPTION
## Summary
- add max_post_age_minutes to configuration
- skip statuses older than max_post_age_minutes
- document max_post_age_minutes in README and sample config

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68a18fe4e8b4832292336dfc159174dd