### PR TITLE
feat: raise default daily public cap to 48

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ subscribed_instances:
 filtered_instances:
   - example.com
 
-daily_public_cap: 24
+daily_public_cap: 48
 per_hour_public_cap: 1
 rotate_instances: true
 require_media: true

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -27,7 +27,7 @@ subscribed_instances:
 filtered_instances:
   - example.com
 
-daily_public_cap: 24
+daily_public_cap: 48
 per_hour_public_cap: 1
 rotate_instances: true
 require_media: true

--- a/hype/config.py
+++ b/hype/config.py
@@ -37,7 +37,7 @@ class Config:
     filtered_instances: List = []
     profile_prefix: str = ""
     fields: dict = {}
-    daily_public_cap: int = 24
+    daily_public_cap: int = 48
     per_hour_public_cap: int = 1
     rotate_instances: bool = True
     require_media: bool = True

--- a/tests/test_seen_status.py
+++ b/tests/test_seen_status.py
@@ -21,6 +21,8 @@ class DummyConfig:
         self.rotate_instances = True
         self.require_media = False
         self.skip_sensitive_without_cw = False
+        self.min_reblogs = 0
+        self.min_favourites = 0
         self.languages_allowlist = []
         self.state_path = path
 


### PR DESCRIPTION
## Summary
- raise daily_public_cap default to 48
- update configuration docs
- fix tests using DummyConfig missing fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a874cd34248322952fedc83e4b0f0c