### PR TITLE
feat: make seen cache size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,18 @@ languages_allowlist:
   - en
   - sv
 state_path: "/app/secrets/state.json"
+seen_cache_size: 6000
 ```
 
 `min_reblogs` and `min_favourites` let you ignore posts that haven't gained enough traction yet.
+`seen_cache_size` limits how many posts the bot remembers to avoid boosting duplicates.
 
 ## Features
 
 - Boost trending posts from other Mastodon instances
 - Update bot profile with list of subscribed instances
 - Rotate through subscribed instances
-- Skip duplicates across instances by tracking canonical URLs
+- Skip duplicates across instances by tracking canonical URLs with a configurable cache
 - Enforce hourly and daily caps on public boosts
 - Skip reposts and filter posts without media or missing content warnings
 - Skip posts with too few reblogs or favourites

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,3 +38,5 @@ languages_allowlist:
   - en
   - sv
 state_path: "/app/secrets/state.json"
+# Number of posts to remember for duplicate detection
+seen_cache_size: 6000

--- a/hype/config.py
+++ b/hype/config.py
@@ -1,6 +1,5 @@
 import logging
 from typing import List
-from datetime import timezone
 
 import yaml
 
@@ -46,6 +45,7 @@ class Config:
     min_favourites: int = 0
     languages_allowlist: list = []
     state_path: str = "/app/secrets/state.json"
+    seen_cache_size: int = 6000
 
     def __init__(self):
         # auth file containing login info
@@ -138,6 +138,9 @@ class Config:
                     "languages_allowlist", self.languages_allowlist
                 ) or []
                 self.state_path = config.get("state_path", self.state_path)
+                self.seen_cache_size = int(
+                    config.get("seen_cache_size", self.seen_cache_size)
+                )
 
 
 class ConfigException(Exception):

--- a/hype/hype.py
+++ b/hype/hype.py
@@ -22,7 +22,10 @@ class Hype:
         self.log = logging.getLogger("hype")
         self.instance_index = 0
         self.state = self._load_state()
-        self._seen = deque(self.state.get("seen_status_ids", []), maxlen=6000)
+        self._seen = deque(
+            self.state.get("seen_status_ids", []),
+            maxlen=self.config.seen_cache_size,
+        )
         self.log.info("Config loaded")
 
     def login(self):

--- a/tests/test_seen_status.py
+++ b/tests/test_seen_status.py
@@ -25,6 +25,7 @@ class DummyConfig:
         self.min_favourites = 0
         self.languages_allowlist = []
         self.state_path = path
+        self.seen_cache_size = 6000
 
 
 def status_data(i, u):
@@ -61,4 +62,13 @@ def test_skips_duplicates_across_instances(tmp_path):
     hype._boost_instance(inst2)
     assert client.status_reblog.call_count == 1
     assert list(hype._seen).count("https://a/1") == 1
+
+
+def test_seen_cache_respects_size(tmp_path):
+    cfg = DummyConfig(str(tmp_path / "state.json"))
+    cfg.seen_cache_size = 2
+    hype = Hype(cfg)
+    hype._remember_status(status_data("1", "https://a/1"))
+    hype._remember_status(status_data("2", "https://a/2"))
+    assert list(hype._seen) == ["2", "https://a/2"]
 


### PR DESCRIPTION
## Summary
- allow setting the size of the seen status cache via `seen_cache_size`
- document the new option in config and README
- cover custom cache size with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8766cfeac8322b497f363d3545f22