### PR TITLE
Add hashtag-based ranking for trending posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,14 @@ languages_allowlist:
   - sv
 state_path: "/app/secrets/state.json"
 seen_cache_size: 6000
+hashtag_scores:
+  python: 10
+  rust: 5
 ```
 
 `min_reblogs` and `min_favourites` let you ignore posts that haven't gained enough traction yet.
 `seen_cache_size` limits how many posts the bot remembers to avoid boosting duplicates.
+`hashtag_scores` lets you push posts with certain hashtags to the front by assigning weights.
 
 ## Features
 
@@ -88,6 +92,7 @@ seen_cache_size: 6000
 - Enforce hourly and daily caps on public boosts
 - Skip reposts and filter posts without media or missing content warnings
 - Skip posts with too few reblogs or favourites
+- Prioritize posts containing weighted hashtags
 
 ---
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,3 +40,6 @@ languages_allowlist:
 state_path: "/app/secrets/state.json"
 # Number of posts to remember for duplicate detection
 seen_cache_size: 6000
+hashtag_scores:
+  python: 10
+  rust: 5

--- a/hype/config.py
+++ b/hype/config.py
@@ -46,6 +46,7 @@ class Config:
     languages_allowlist: list = []
     state_path: str = "/app/secrets/state.json"
     seen_cache_size: int = 6000
+    hashtag_scores: dict = {}
 
     def __init__(self):
         # auth file containing login info
@@ -141,6 +142,10 @@ class Config:
                 self.seen_cache_size = int(
                     config.get("seen_cache_size", self.seen_cache_size)
                 )
+                self.hashtag_scores = {
+                    k.lower(): int(v)
+                    for k, v in (config.get("hashtag_scores") or {}).items()
+                }
 
 
 class ConfigException(Exception):

--- a/hype/hype.py
+++ b/hype/hype.py
@@ -155,7 +155,15 @@ class Hype:
                 self.log.info("Public cap reached. Skipping boosting this cycle.")
                 return
             mastodon_client = self.init_client(instance.name)
-            trending_statuses = mastodon_client.trending_statuses()[: instance.limit]
+            trending_statuses = mastodon_client.trending_statuses()
+            trending_statuses = sorted(
+                trending_statuses,
+                key=lambda s: sum(
+                    self.config.hashtag_scores.get(t.get("name", "").lower(), 0)
+                    for t in s.get("tags", [])
+                ),
+                reverse=True,
+            )[: instance.limit]
             total = len(trending_statuses)
             processed = 0
             for trending_status in trending_statuses:

--- a/tests/test_hashtag_scoring.py
+++ b/tests/test_hashtag_scoring.py
@@ -1,0 +1,30 @@
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hype.hype import Hype
+from tests.test_seen_status import DummyConfig, status_data
+
+
+def test_prioritizes_weighted_hashtags(tmp_path):
+    cfg = DummyConfig(str(tmp_path / "state.json"))
+    cfg.hashtag_scores = {"python": 10}
+    hype = Hype(cfg)
+    hype.client = MagicMock()
+    hype.client.search_v2.side_effect = [
+        {"statuses": [status_data("1", "https://a/1")]},
+        {"statuses": [status_data("2", "https://a/2")]},
+    ]
+    m = MagicMock()
+    m.trending_statuses.return_value = [
+        {"uri": "https://a/2", "tags": [{"name": "rust"}]},
+        {"uri": "https://a/1", "tags": [{"name": "python"}]},
+    ]
+    hype.init_client = MagicMock(return_value=m)
+    inst = types.SimpleNamespace(name="i", limit=2)
+    hype._boost_instance(inst)
+    first_search = hype.client.search_v2.call_args_list[0][0][0]
+    assert first_search == "https://a/1"

--- a/tests/test_seen_status.py
+++ b/tests/test_seen_status.py
@@ -26,6 +26,7 @@ class DummyConfig:
         self.languages_allowlist = []
         self.state_path = path
         self.seen_cache_size = 6000
+        self.hashtag_scores = {}
 
 
 def status_data(i, u):


### PR DESCRIPTION
## Summary
- score trending posts with configurable hashtag weights
- document hashtag_scores in config and README
- test that weighted hashtags are processed first

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3fc1f7d80832293ec9cdec1cbc298