### PR TITLE
Automate develop branch recreation after merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
-# .github/workflows/main.yml
 name: Build and Release
 
 on:
@@ -6,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  delete:
+    branches: [ "develop" ]
 
 permissions:
   contents: write
@@ -100,3 +101,22 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  recreate-develop:
+    if: github.event_name == 'delete'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const mainRef = await github.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/main'
+            })
+            await github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/heads/develop',
+              sha: mainRef.data.object.sha
+            })

--- a/README.md
+++ b/README.md
@@ -94,5 +94,9 @@ hashtag_scores:
 - Skip posts with too few reblogs or favourites
 - Prioritize posts containing weighted hashtags
 
+## Branches
+
+Work starts on `develop`. When it's merged into `main` and deleted, a workflow recreates `develop` from `main`. If that job fails, create the branch manually.
+
 ---
  


### PR DESCRIPTION
## Summary
- recreate `develop` branch automatically when it's deleted after merging to `main`
- document the branch workflow for contributors

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4389dc6b08322b5b8ebdd5c4f36be