### PR TITLE
refactor(hype): aggregate trending statuses before boosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # hype
 
-This Mastodon bot transfers the trends from other instances directly to your personal timeline. You decide which instances it fetches and how much you want to see per instance.
+This Mastodon bot pulls trending posts from chosen instances, ranks them, and boosts the top results to your timeline. You decide which instances it fetches and how much you want to see per instance.
 
 ## Why
 
@@ -64,7 +64,6 @@ filtered_instances:
 
 daily_public_cap: 48
 per_hour_public_cap: 1
-rotate_instances: true
 require_media: true
 skip_sensitive_without_cw: true
 min_reblogs: 0
@@ -87,7 +86,7 @@ hashtag_scores:
 
 - Boost trending posts from other Mastodon instances
 - Update bot profile with list of subscribed instances
-- Rotate through subscribed instances
+- Rank collected posts across instances before boosting
 - Skip duplicates across instances by tracking canonical URLs with a configurable cache
 - Enforce hourly and daily caps on public boosts
 - Skip reposts and filter posts without media or missing content warnings

--- a/tests/test_hashtag_scoring.py
+++ b/tests/test_hashtag_scoring.py
@@ -12,6 +12,8 @@ from tests.test_seen_status import DummyConfig, status_data
 def test_prioritizes_weighted_hashtags(tmp_path):
     cfg = DummyConfig(str(tmp_path / "state.json"))
     cfg.hashtag_scores = {"python": 10}
+    inst = types.SimpleNamespace(name="i", limit=2)
+    cfg.subscribed_instances = [inst]
     hype = Hype(cfg)
     hype.client = MagicMock()
     hype.client.search_v2.side_effect = [
@@ -24,7 +26,6 @@ def test_prioritizes_weighted_hashtags(tmp_path):
         {"uri": "https://a/1", "tags": [{"name": "python"}]},
     ]
     hype.init_client = MagicMock(return_value=m)
-    inst = types.SimpleNamespace(name="i", limit=2)
-    hype._boost_instance(inst)
+    hype.boost()
     first_search = hype.client.search_v2.call_args_list[0][0][0]
     assert first_search == "https://a/1"

--- a/tests/test_seen_status.py
+++ b/tests/test_seen_status.py
@@ -45,6 +45,9 @@ def status_data(i, u):
 
 def test_skips_duplicates_across_instances(tmp_path):
     cfg = DummyConfig(str(tmp_path / "state.json"))
+    inst1 = types.SimpleNamespace(name="i1", limit=1)
+    inst2 = types.SimpleNamespace(name="i2", limit=1)
+    cfg.subscribed_instances = [inst1, inst2]
     hype = Hype(cfg)
     client = MagicMock()
     client.search_v2.side_effect = [
@@ -57,10 +60,7 @@ def test_skips_duplicates_across_instances(tmp_path):
     m2 = MagicMock()
     m2.trending_statuses.return_value = [{"uri": "https://a/1"}]
     hype.init_client = MagicMock(side_effect=[m1, m2])
-    inst1 = types.SimpleNamespace(name="i1", limit=1)
-    inst2 = types.SimpleNamespace(name="i2", limit=1)
-    hype._boost_instance(inst1)
-    hype._boost_instance(inst2)
+    hype.boost()
     assert client.status_reblog.call_count == 1
     assert list(hype._seen).count("https://a/1") == 1
 


### PR DESCRIPTION
## Summary
- collect trending posts from all subscribed instances and rank them globally
- add helper for fetching trending posts without boosting
- update docs and tests for global ranking flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4407524b083228bfeb0c61e966da6