### PR TITLE
feat: normalize scores and cap boosts per run

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ filtered_instances:
 
 daily_public_cap: 48
 per_hour_public_cap: 1
+max_boosts_per_run: 5
 max_boosts_per_author_per_day: 1
 prefer_media: true
 require_media: true
@@ -85,12 +86,14 @@ hashtag_scores:
 `hashtag_scores` lets you push posts with certain hashtags to the front by assigning weights.
 `prefer_media` gives posts with attachments a small edge when ranking.
 `max_boosts_per_author_per_day` stops the bot from boosting the same author over and over.
+`max_boosts_per_run` limits how many posts get boosted in each run.
 
 ## Features
 
 - Boost trending posts from other Mastodon instances
 - Update bot profile with list of subscribed instances
 - Rank collected posts using hashtags, engagement, and optional media preference
+- Normalize scores on a 0–100 scale and break ties by latest timestamp
 - Skip duplicates across instances by tracking canonical URLs with a configurable cache
 - Enforce hourly and daily caps on public boosts
 - Limit boosts for any single author per day

--- a/hype/config.py
+++ b/hype/config.py
@@ -38,6 +38,7 @@ class Config:
     fields: dict = {}
     daily_public_cap: int = 48
     per_hour_public_cap: int = 1
+    max_boosts_per_run: int = 5
     max_boosts_per_author_per_day: int = 1
     rotate_instances: bool = True
     prefer_media: bool = False
@@ -119,6 +120,9 @@ class Config:
                 )
                 self.per_hour_public_cap = int(
                     config.get("per_hour_public_cap", self.per_hour_public_cap)
+                )
+                self.max_boosts_per_run = int(
+                    config.get("max_boosts_per_run", self.max_boosts_per_run)
                 )
                 self.max_boosts_per_author_per_day = int(
                     config.get(

--- a/tests/test_boosting.py
+++ b/tests/test_boosting.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+import types
+from datetime import datetime
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hype.hype import Hype
+from tests.test_seen_status import DummyConfig, status_data
+
+
+def test_normalizes_and_sorts_candidates(tmp_path):
+    cfg = DummyConfig(str(tmp_path / "state.json"))
+    hype = Hype(cfg)
+    entries = [
+        {"status": {"created_at": "2024-01-01T00:00:00Z"}, "score": 5, "created_at": datetime(2024, 1, 1)},
+        {"status": {"created_at": "2024-01-03T00:00:00Z"}, "score": 15, "created_at": datetime(2024, 1, 3)},
+        {"status": {"created_at": "2024-01-02T00:00:00Z"}, "score": 15, "created_at": datetime(2024, 1, 2)},
+    ]
+    hype._normalize_scores(entries)
+    scores = [e["score"] for e in entries]
+    assert scores == [0, 100, 100]
+    entries.sort(key=lambda e: (e["score"], e["created_at"]), reverse=True)
+    ordered = [e["created_at"].day for e in entries]
+    assert ordered == [3, 2, 1]
+
+
+def test_respects_max_boosts_per_run(tmp_path):
+    cfg = DummyConfig(str(tmp_path / "state.json"))
+    cfg.max_boosts_per_run = 1
+    inst = types.SimpleNamespace(name="i1", limit=2)
+    cfg.subscribed_instances = [inst]
+    hype = Hype(cfg)
+    trending = [
+        {"uri": "https://a/1", "reblogs_count": 10, "favourites_count": 10, "created_at": "2024-01-02T00:00:00Z"},
+        {"uri": "https://a/2", "reblogs_count": 5, "favourites_count": 5, "created_at": "2024-01-01T00:00:00Z"},
+    ]
+    m = MagicMock()
+    m.trending_statuses.return_value = trending
+    hype.init_client = MagicMock(return_value=m)
+    client = MagicMock()
+    s1 = status_data("1", "https://a/1")
+    s1["created_at"] = "2024-01-02T00:00:00Z"
+    s2 = status_data("2", "https://a/2")
+    s2["created_at"] = "2024-01-01T00:00:00Z"
+    client.search_v2.side_effect = [{"statuses": [s1]}, {"statuses": [s2]}]
+    hype.client = client
+    hype.boost()
+    assert client.status_reblog.call_count == 1

--- a/tests/test_seen_status.py
+++ b/tests/test_seen_status.py
@@ -18,6 +18,7 @@ class DummyConfig:
         self.fields = {}
         self.daily_public_cap = 10
         self.per_hour_public_cap = 10
+        self.max_boosts_per_run = 10
         self.max_boosts_per_author_per_day = 10
         self.rotate_instances = True
         self.prefer_media = False


### PR DESCRIPTION
## Summary
- normalize candidate scores to a 0–100 range and tie-break by timestamp
- stop boosting after configurable `max_boosts_per_run`
- document per-run cap and score normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c44f0af3e88322af65a822c7629cc7