### PR TITLE
feat: reset daily author boost list

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ hashtag_scores:
 `seen_cache_size` limits how many posts the bot remembers to avoid boosting duplicates.
 `hashtag_scores` lets you push posts with certain hashtags to the front by assigning weights.
 `prefer_media` gives posts with attachments a small edge when ranking.
-`max_boosts_per_author_per_day` stops the bot from boosting the same author over and over.
+`max_boosts_per_author_per_day` stops the bot from boosting the same author over and over. Boosted authors are tracked for a day and the list resets each midnight UTC.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- track boosted authors for a day and clear list when the date changes
- persist daily author list and last-seen day in state file
- document daily author tracking and add regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c45091b10483229aa3b2799c6627df