### PR TITLE
feat(config): add author diversity option and media bonus

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ daily_public_cap: 48
 per_hour_public_cap: 1
 max_boosts_per_run: 5
 max_boosts_per_author_per_day: 1
-prefer_media: true
+author_diversity_enforced: true
+prefer_media: 1
 require_media: true
 skip_sensitive_without_cw: true
 min_reblogs: 0
@@ -84,9 +85,10 @@ hashtag_scores:
 `min_reblogs` and `min_favourites` let you ignore posts that haven't gained enough traction yet.
 `seen_cache_size` limits how many posts the bot remembers to avoid boosting duplicates.
 `hashtag_scores` lets you push posts with certain hashtags to the front by assigning weights.
-`prefer_media` gives posts with attachments a small edge when ranking.
-`max_boosts_per_author_per_day` stops the bot from boosting the same author over and over.
+`prefer_media` adds the given bonus to posts with attachments; set to `true` for a default of `1`.
+`author_diversity_enforced` respects `max_boosts_per_author_per_day` when enabled.
 `max_boosts_per_run` limits how many posts get boosted in each run.
+`max_boosts_per_author_per_day` stops the bot from boosting the same author over and over.
 
 ## Features
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,9 +29,11 @@ filtered_instances:
 
 daily_public_cap: 48
 per_hour_public_cap: 1
+max_boosts_per_run: 5
 max_boosts_per_author_per_day: 1
+author_diversity_enforced: true
 rotate_instances: true
-prefer_media: false
+prefer_media: 1
 require_media: true
 skip_sensitive_without_cw: true
 min_reblogs: 0

--- a/hype/config.py
+++ b/hype/config.py
@@ -40,8 +40,9 @@ class Config:
     per_hour_public_cap: int = 1
     max_boosts_per_run: int = 5
     max_boosts_per_author_per_day: int = 1
+    author_diversity_enforced: bool = True
     rotate_instances: bool = True
-    prefer_media: bool = False
+    prefer_media: float = 0
     require_media: bool = True
     skip_sensitive_without_cw: bool = True
     min_reblogs: int = 0
@@ -130,12 +131,23 @@ class Config:
                         self.max_boosts_per_author_per_day,
                     )
                 )
+                self.author_diversity_enforced = bool(
+                    config.get(
+                        "author_diversity_enforced",
+                        self.author_diversity_enforced,
+                    )
+                )
                 self.rotate_instances = bool(
                     config.get("rotate_instances", self.rotate_instances)
                 )
-                self.prefer_media = bool(
-                    config.get("prefer_media", self.prefer_media)
-                )
+                pm = config.get("prefer_media", self.prefer_media)
+                if isinstance(pm, bool):
+                    self.prefer_media = 1 if pm else 0
+                else:
+                    try:
+                        self.prefer_media = float(pm)
+                    except (TypeError, ValueError):
+                        self.prefer_media = self.prefer_media
                 self.require_media = bool(
                     config.get("require_media", self.require_media)
                 )

--- a/hype/hype.py
+++ b/hype/hype.py
@@ -110,8 +110,11 @@ class Hype:
             sid in self._seen
             or url in self._seen
             or status.get("reblogged")
-            or self._boosted_today.get(author, 0)
-            >= self.config.max_boosts_per_author_per_day
+            or (
+                self.config.author_diversity_enforced
+                and self._boosted_today.get(author, 0)
+                >= self.config.max_boosts_per_author_per_day
+            )
         )
 
     def _remember_status(self, status: dict):
@@ -151,9 +154,7 @@ class Hype:
         reblogs = math.log1p(status.get("reblogs_count", 0)) * 2
         favourites = math.log1p(status.get("favourites_count", 0))
         media_bonus = (
-            1
-            if self.config.prefer_media and status.get("media_attachments")
-            else 0
+            self.config.prefer_media if status.get("media_attachments") else 0
         )
         return tag_score + reblogs + favourites + media_bonus
 

--- a/tests/test_score_status.py
+++ b/tests/test_score_status.py
@@ -24,11 +24,11 @@ def test_scores_hashtags_and_engagement(tmp_path):
 
 def test_media_bonus(tmp_path):
     cfg = DummyConfig(str(tmp_path / "state.json"))
-    cfg.prefer_media = True
+    cfg.prefer_media = 0.5
     hype = Hype(cfg)
     s = status_data("1", "https://a/1")
     s["media_attachments"] = [1]
-    assert hype.score_status(s) == pytest.approx(1)
+    assert hype.score_status(s) == pytest.approx(0.5)
 
 
 def test_no_media_bonus_without_preference(tmp_path):

--- a/tests/test_seen_status.py
+++ b/tests/test_seen_status.py
@@ -20,6 +20,7 @@ class DummyConfig:
         self.per_hour_public_cap = 10
         self.max_boosts_per_run = 10
         self.max_boosts_per_author_per_day = 10
+        self.author_diversity_enforced = True
         self.rotate_instances = True
         self.prefer_media = False
         self.require_media = False
@@ -83,4 +84,13 @@ def test_respects_author_daily_limit(tmp_path):
     hype = Hype(cfg)
     hype._remember_status(status_data("1", "https://a/1"))
     assert hype._seen_status(status_data("2", "https://a/2"))
+
+
+def test_can_disable_author_limit(tmp_path):
+    cfg = DummyConfig(str(tmp_path / "state.json"))
+    cfg.max_boosts_per_author_per_day = 1
+    cfg.author_diversity_enforced = False
+    hype = Hype(cfg)
+    hype._remember_status(status_data("1", "https://a/1"))
+    assert not hype._seen_status(status_data("2", "https://a/2"))
 


### PR DESCRIPTION
## Summary
- allow numeric media bonus and author diversity toggle
- document new config options
- test author limit override and media bonus value

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c456f5dd8c832294a64ad19b631593