### PR TITLE
refactor(config)!: drop rotate_instances option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ hashtag_scores:
 `max_boosts_per_run` limits how many posts get boosted in each run.
 `max_boosts_per_author_per_day` stops the bot from boosting the same author over and over.
 
+**Migration note**: The `rotate_instances` option has been removed. The bot now checks every subscribed instance each run, so older configs should drop this field.
+
 ## Features
 
 - Boost trending posts from other Mastodon instances

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,7 +32,6 @@ per_hour_public_cap: 1
 max_boosts_per_run: 5
 max_boosts_per_author_per_day: 1
 author_diversity_enforced: true
-rotate_instances: true
 prefer_media: 1
 require_media: true
 skip_sensitive_without_cw: true

--- a/hype/config.py
+++ b/hype/config.py
@@ -41,7 +41,6 @@ class Config:
     max_boosts_per_run: int = 5
     max_boosts_per_author_per_day: int = 1
     author_diversity_enforced: bool = True
-    rotate_instances: bool = True
     prefer_media: float = 0
     require_media: bool = True
     skip_sensitive_without_cw: bool = True
@@ -136,9 +135,6 @@ class Config:
                         "author_diversity_enforced",
                         self.author_diversity_enforced,
                     )
-                )
-                self.rotate_instances = bool(
-                    config.get("rotate_instances", self.rotate_instances)
                 )
                 pm = config.get("prefer_media", self.prefer_media)
                 if isinstance(pm, bool):

--- a/tests/test_seen_status.py
+++ b/tests/test_seen_status.py
@@ -21,7 +21,6 @@ class DummyConfig:
         self.max_boosts_per_run = 10
         self.max_boosts_per_author_per_day = 10
         self.author_diversity_enforced = True
-        self.rotate_instances = True
         self.prefer_media = False
         self.require_media = False
         self.skip_sensitive_without_cw = False


### PR DESCRIPTION
## Summary
- remove deprecated `rotate_instances` configuration option and related test/example
- note removal in docs with migration guidance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4594aa8988322ac6e9062996a0bf3