### PR TITLE
test: ensure seen cache avoids cross-instance duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ hashtag_scores:
 ```
 
 `min_reblogs` and `min_favourites` let you ignore posts that haven't gained enough traction yet.
-`seen_cache_size` limits how many posts the bot remembers to avoid boosting duplicates.
+`seen_cache_size` sets how many posts the bot keeps in memory to avoid boosting the same thing twice. A bigger cache catches more duplicates but uses more RAM and takes longer to search.
 `hashtag_scores` lets you push posts with certain hashtags to the front by assigning weights.
 `prefer_media` adds the given bonus to posts with attachments; set to `true` for a default of `1`.
 `author_diversity_enforced` respects `max_boosts_per_author_per_day` when enabled.

--- a/tests/test_seen_status.py
+++ b/tests/test_seen_status.py
@@ -93,3 +93,21 @@ def test_can_disable_author_limit(tmp_path):
     hype._remember_status(status_data("1", "https://a/1"))
     assert not hype._seen_status(status_data("2", "https://a/2"))
 
+
+def test_seen_status_duplicate_url(tmp_path):
+    cfg = DummyConfig(str(tmp_path / "state.json"))
+    hype = Hype(cfg)
+    first = status_data("1", "https://a/1")
+    second = status_data("2", "https://a/1")
+    hype._remember_status(first)
+    assert hype._seen_status(second)
+
+
+def test_seen_status_duplicate_id(tmp_path):
+    cfg = DummyConfig(str(tmp_path / "state.json"))
+    hype = Hype(cfg)
+    first = status_data("1", "https://a/1")
+    second = status_data("1", "https://b/1")
+    hype._remember_status(first)
+    assert hype._seen_status(second)
+


### PR DESCRIPTION
## Summary
- add tests to confirm `_seen_status` blocks duplicate URLs and IDs across instances
- document memory and lookup cost of the seen-status cache

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c45dd1bb64832293beb4752d0656d6