### PR TITLE
test: cover public cap counter resets

### DIFF
--- a/tests/test_public_cap.py
+++ b/tests/test_public_cap.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hype.hype import Hype
+from tests.test_seen_status import DummyConfig
+
+
+class FixedDatetime(datetime):
+    current = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls.current
+
+
+def test_public_cap_flips_and_resets(tmp_path):
+    cfg = DummyConfig(str(tmp_path / "state.json"))
+    cfg.daily_public_cap = 2
+    cfg.per_hour_public_cap = 1
+    hype = Hype(cfg)
+    with patch("hype.hype.datetime", FixedDatetime):
+        FixedDatetime.current = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        assert hype._public_cap_available()
+        hype._count_public_boost()
+        assert not hype._public_cap_available()
+        FixedDatetime.current = FixedDatetime.current + timedelta(hours=1)
+        assert hype._public_cap_available()
+        assert hype.state["hour_count"] == 0
+        assert hype.state["day_count"] == 1
+        hype._count_public_boost()
+        assert not hype._public_cap_available()
+        FixedDatetime.current = FixedDatetime.current + timedelta(days=1)
+        assert hype._public_cap_available()
+        assert hype.state["hour_count"] == 0
+        assert hype.state["day_count"] == 0


### PR DESCRIPTION
## Summary
- test public cap availability after boost counting
- verify hour and day counters reset when time advances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c45f68d1f88322bc3089bc795bd8e5