### PR TITLE
fix(ci): use rest api for branch recreation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,12 +149,12 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const mainRef = await github.git.getRef({
+            const mainRef = await github.rest.git.getRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: 'heads/main'
             })
-            await github.git.createRef({
+            await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: 'refs/heads/develop',


### PR DESCRIPTION
## Summary
- use `github.rest.git` in branch recreation script

## Testing
- `pytest -q`
- `docker build -t hypebot-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68c53161ca5883229e5914d85af777c0